### PR TITLE
add depenedency for load-grunt-tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "karma-mocha": "^0.1.9",
     "karma-sinon-chai": "^0.2.0",
     "karma-spec-reporter": "0.0.13",
+    "load-grunt-tasks": "^1.0.0",
     "mocha": "^1.21.5",
     "mockasing": "0.0.3",
     "protractor": "^1.3.1",


### PR DESCRIPTION
The library is missing or at least thinks it needs load-grunt-tasks
